### PR TITLE
Added MySQL conditional for post-install script

### DIFF
--- a/drupal/templates/job/post-install-site-install.yaml
+++ b/drupal/templates/job/post-install-site-install.yaml
@@ -47,7 +47,9 @@ spec:
               # Run site install
               time drush site:install {{ .Values.drupal.profile }} \
                 --sites-subdir=default \
+                {{- if .Values.mysql.enabled }}
                 --db-url="mysql://{{ .Values.mysql.mysqlUser }}:$MYSQL_PASSWORD@{{ .Release.Name }}-mysql:{{ .Values.mysql.service.port }}/{{ .Values.mysql.mysqlDatabase }}" \
+                {{ end }}
                 --account-name={{ .Values.drupal.username }} \
                 --account-pass=$DRUPAL_ADMIN_PASSWORD \
                 --site-mail={{ .Values.drupal.siteEmail | quote }} \


### PR DESCRIPTION
I ran into an issue when setting up an `external` database as part of this Helm chart. Even though I had disabled the MySQL pod from being created, the `post-install` script would error out since Drush was trying to install against it.

Adding this conditional fixed the issue for me.