### PR TITLE
Configurable nginx value

### DIFF
--- a/drupal/conf/nginx.conf
+++ b/drupal/conf/nginx.conf
@@ -12,7 +12,11 @@ events {
 
 http {
   access_log /proc/self/fd/1;
+{{- if .Values.nginx.client_max_body_size }}
+  client_max_body_size {{ .Values.nginx.client_max_body_size }};
+{{- else }}
   client_max_body_size 20m;
+{{- end }}
   default_type application/octet-stream;
   gzip on;
   gzip_buffers 16 8k;

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -232,6 +232,8 @@ nginx:
   securityContext:
     enabled: true
     fsGroup: 33
+  
+  client_max_body_size: 20m
 
 # Specify an external database
 # Useful for managed offerings from your Cloud Provider


### PR DESCRIPTION
There is a file upload size limitation of `20m` when using the current Nginx config values. This is a decent size for most deployments however we are running into issues when trying to upload any file larger than this into Drupal, receiving an Nginx error message of `413 Request Entity Too Large`.

The addition of a few lines will make the `client_max_body_size` Nginx value configurable for deployments that require larger file uploads.