### PR TITLE
Added PDO support for external DBs

### DIFF
--- a/drupal/conf/settings.d8.php
+++ b/drupal/conf/settings.d8.php
@@ -97,6 +97,13 @@ $databases['default']['default'] = array (
   'prefix' => '',
   'namespace' => 'Drupal\Core\Database\Driver\{{ .Values.external.driver }}',
   'driver' => '{{ .Values.external.driver }}',
+  'pdo' => array (
+  {{- range .Values.external.pdo }}
+    {{- range $key, $value := . }}
+    {{ $key }} => {{ $value | quote }},
+    {{- end }}
+  {{- end }}
+  ),
 );
 {{- else if .Values.osb.enabled }}
 $databases['default']['default'] = array (

--- a/drupal/conf/settings.d9.php
+++ b/drupal/conf/settings.d9.php
@@ -99,6 +99,13 @@ $databases['default']['default'] = [
   'namespace' => 'Drupal\Core\Database\Driver\{{ .Values.external.driver }}',
   'driver' => '{{ .Values.external.driver }}',
   'collation' => 'utf8mb4_general_ci',
+  'pdo' => [
+  {{- range .Values.external.pdo }}
+    {{- range $key, $value := . }}
+    {{ $key }} => {{ $value | quote }},
+    {{- end }}
+  {{- end }}
+  ],
 ];
 {{- else if .Values.osb.enabled }}
 $databases['default']['default'] = [


### PR DESCRIPTION
Ran into a corner case for one of our Drupal instances that requires a TLS connection to its cloud-managed database. Drupal requires a couple extra database PDO configs to achieve this so I figured we could add this as part of the Helm template to make it configurable and future-proof. The added templating within the `settings.php` file allows a developer to add something like this to their `values.yaml` file:

```
external:
  enabled: true
  driver: mysql
  port: 3306
  host: myhost.com
  database: db_name
  user: db_user
  password: db_pass
  pdo:
    - PDO::MYSQL_ATTR_SSL_CA: '/my/cert/location.pem'
    - PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT: false
```