### PR TITLE
feat(config): Move config to /private mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-## 0.6.8
+## 0.7.0
 
-- Resolved issues with the Redis integration
-
-## 0.6.1
-
-- Resolved issues with the Varnish integration
+- Added support for Azure Shared Disk
+- Added Redis integration
+- Added Varnish integration
 
 ## 0.6.0
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,10 +63,6 @@ Statistics Canada is looking at levearing Kubernetes for a majority of its workl
 - Cert-manager: Using Let's Encrypt, providing automatic certificate issuance and renewal
 - Open Policy Agent: Provides enforcement of defined policies (for example, using images from authorized sources only)
 
-#### Canadian Digital Services
-
-The Canadian Digital Services (CDS) develops all of their applications to run in a Kubernetes-based environment on Google Cloud. They are actively involved in promoting Kubernetes, DevOps and other modern workflows across the Government of Canada. They are launching tools suchs as GC Notify, their Security Goals compliance reporting tool, and work closely with GC Tools and GC Connex.
-
 #### Others
 
 Many others across the Government of Canada, municipalities and internal Government agencies are actively and/or investigating Kubernetes. This includes Shared Services Canada (SSC) through their investigation into a managed cloud platform powered by OpenShift (Kubernetes) for use by other departments. The Communication Security Establishment (CSE) is leveraging Kubernetes in their on-premise computing environment, running cloud native technologies in a restricted environment.

--- a/docs/kind.yaml
+++ b/docs/kind.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  # add a mount from /path/to/my/files on the host to /files on the node
+  extraMounts:
+  - hostPath: /tmp/drupal/shared/drupal-public
+    containerPath: /mnt/drupal/drupal-public
+  - hostPath: /tmp/drupal/shared/drupal-private
+    containerPath: /mnt/drupal/drupal-private

--- a/drupal/conf/settings.d8.php
+++ b/drupal/conf/settings.d8.php
@@ -775,7 +775,7 @@ if ($drupal_settings !== 'production') {
 /**
 * Set private file path directory.
 */
-$settings['file_private_path'] =  '/var/www/private';
+$settings['file_private_path'] =  '/private';
 
 /**
 * Load local development override configuration, if available.
@@ -793,11 +793,11 @@ if ($drupal_settings === 'development' && file_exists(__DIR__ . '/settings.local
 
 /** Everything after here is added by the installation process.
 *
-* TODO: improve the installtion by putting the settings.local part below these
+* TODO: improve the installation by putting the settings.local part below these
 * settings.
 */
 
-$config_directories[CONFIG_SYNC_DIRECTORY] = '/config/sync';
+$config_directories[CONFIG_SYNC_DIRECTORY] = '/private/config/sync';
 
 {{- if .Values.drupal.configSplit.enabled }}
 /**
@@ -810,7 +810,7 @@ $config_directories[CONFIG_SYNC_DIRECTORY] = '/config/sync';
  *
  * To disable this functionality simply set the following parameters:
  * $wxt_override_config_dirs = FALSE;
- * $settings['config_sync_directory'] = $dir . "/config/$site_dir";
+ * $settings['config_sync_directory'] = $dir . "/private/config/$site_dir";
  *
  * See https://github.com/acquia/blt/blob/12.x/settings/config.settings.php
  * for more information.
@@ -822,8 +822,8 @@ if (!isset($wxt_override_config_dirs)) {
   $wxt_override_config_dirs = TRUE;
 }
 if ($wxt_override_config_dirs) {
-  $config_directories['sync'] = $repo_root . "/var/www/html/sites/default/files/config/default";
-  $settings['config_sync_directory'] = $repo_root . "/var/www/html/sites/default/files/config/default";
+  $config_directories['sync'] = $repo_root . "/private/config/default";
+  $settings['config_sync_directory'] = $repo_root . "/private/config/default";
 }
 $split_filename_prefix = 'config_split.config_split';
 if (isset($config_directories['sync'])) {

--- a/drupal/conf/settings.d9.php
+++ b/drupal/conf/settings.d9.php
@@ -829,7 +829,7 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 #   include $app_root . '/' . $site_path . '/settings.local.php';
 # }
 
-$settings["config_sync_directory"] = 'sites/default/files/config/sync';
+$settings["config_sync_directory"] = '/private/config/sync';
 
 {{- if .Values.drupal.configSplit.enabled }}
 /**
@@ -842,7 +842,7 @@ $settings["config_sync_directory"] = 'sites/default/files/config/sync';
  *
  * To disable this functionality simply set the following parameters:
  * $wxt_override_config_dirs = FALSE;
- * $settings['config_sync_directory'] = $dir . "/config/$site_dir";
+ * $settings['config_sync_directory'] = $dir . "/private/config/$site_dir";
  *
  * See https://github.com/acquia/blt/blob/12.x/settings/config.settings.php
  * for more information.
@@ -854,8 +854,8 @@ if (!isset($wxt_override_config_dirs)) {
   $wxt_override_config_dirs = TRUE;
 }
 if ($wxt_override_config_dirs) {
-  $config_directories['sync'] = $repo_root . "/var/www/html/sites/default/files/config/default";
-  $settings['config_sync_directory'] = $repo_root . "/var/www/html/sites/default/files/config/default";
+  $config_directories['sync'] = $repo_root . "/private/config/default";
+  $settings['config_sync_directory'] = $repo_root . "/private/config/default";
 }
 $split_filename_prefix = 'config_split.config_split';
 if (isset($config_directories['sync'])) {

--- a/drupal/templates/cronjob/drupal-backup.yaml
+++ b/drupal/templates/cronjob/drupal-backup.yaml
@@ -48,30 +48,7 @@ spec:
                 mkdir -p /backup/$BACKUPNAME
                 drush -y sql-dump | gzip > /backup/$BACKUPNAME/db.sql.gz
                 tar czvf /backup/$BACKUPNAME/files.tar.gz --directory=sites/default/files .
-                tar czvf /backup/$BACKUPNAME/private.tar.gz --directory=/var/www/private .
-{{- if .Values.postgresql.pgbouncer.enabled }}
-          - name: pgbouncer
-            image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
-            imagePullPolicy: Always
-            ports:
-              - containerPort: 5432
-            volumeMounts:
-              - name: configfiles
-                mountPath: "/etc/pgbouncer"
-                readOnly: true
-            livenessProbe:
-              tcpSocket:
-                port: 5432
-              periodSeconds: 60
-            lifecycle:
-              preStop:
-                exec:
-                  command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop: ['all']
-{{- end  }}
+                tar czvf /backup/$BACKUPNAME/private.tar.gz --directory=/private .
             env:
 {{- if .Values.external.enabled }}
             - name: EXTERNAL_PASSWORD
@@ -178,7 +155,7 @@ spec:
             - name: twig-cache
               mountPath: /cache/twig
             - name: config-sync
-              mountPath: /config/sync
+              mountPath: /private/config/sync
             - name: backup
               mountPath: /backup
 {{- if not .Values.drupal.disableDefaultFilesMount }}
@@ -186,16 +163,39 @@ spec:
               mountPath: /var/www/html/sites/default/files
               subPath: public
             - name: files
-              mountPath: /var/www/private
+              mountPath: /private
               subPath: private
 {{- end }}
 {{- if .Values.drupal.volumeMounts }}
 {{ toYaml .Values.drupal.volumeMounts | indent 12 }}
 {{- end }}
-{{- if .Values.drupal.imagePullSecrets }}
+{{- if .Values.postgresql.pgbouncer.enabled }}
+          - name: pgbouncer
+            image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
+            imagePullPolicy: Always
+            ports:
+              - containerPort: 5432
+            volumeMounts:
+              - name: configfiles
+                mountPath: "/etc/pgbouncer"
+                readOnly: true
+            livenessProbe:
+              tcpSocket:
+                port: 5432
+              periodSeconds: 60
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ['all']
+{{- end  }}
+          {{- if .Values.drupal.imagePullSecrets }}
           imagePullSecrets:
 {{ toYaml .Values.drupal.imagePullSecrets | indent 12 }}
-{{- end }}
+          {{- end }}
           # Allow non-root user to access PersistentVolume
           securityContext:
 {{ toYaml .Values.drupal.securityContext | indent 12 }}

--- a/drupal/templates/cronjob/drupal.yaml
+++ b/drupal/templates/cronjob/drupal.yaml
@@ -45,29 +45,6 @@ spec:
 
                 # Run cron
                 drush -y core-cron
-{{- if .Values.postgresql.pgbouncer.enabled }}
-          - name: pgbouncer
-            image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
-            imagePullPolicy: Always
-            ports:
-              - containerPort: 5432
-            volumeMounts:
-              - name: configfiles
-                mountPath: "/etc/pgbouncer"
-                readOnly: true
-            livenessProbe:
-              tcpSocket:
-                port: 5432
-              periodSeconds: 60
-            lifecycle:
-              preStop:
-                exec:
-                  command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop: ['all']
-{{- end  }}
             env:
 {{- if .Values.external.enabled }}
             - name: EXTERNAL_PASSWORD
@@ -174,17 +151,42 @@ spec:
             - name: twig-cache
               mountPath: /cache/twig
             - name: config-sync
-              mountPath: /config/sync
+              mountPath: /private/config/sync
+{{- if not .Values.drupal.disableDefaultFilesMount }}
             - name: files
               mountPath: /var/www/html/sites/default/files
               subPath: public
             - name: files
-              mountPath: /var/www/private
+              mountPath: /private
               subPath: private
-{{- if .Values.drupal.imagePullSecrets }}
+{{- end }}
+{{- if .Values.postgresql.pgbouncer.enabled }}
+          - name: pgbouncer
+            image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
+            imagePullPolicy: Always
+            ports:
+              - containerPort: 5432
+            volumeMounts:
+              - name: configfiles
+                mountPath: "/etc/pgbouncer"
+                readOnly: true
+            livenessProbe:
+              tcpSocket:
+                port: 5432
+              periodSeconds: 60
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ['all']
+{{- end  }}
+          {{- if .Values.drupal.imagePullSecrets }}
           imagePullSecrets:
 {{ toYaml .Values.drupal.imagePullSecrets | indent 12 }}
-{{- end }}
+          {{- end }}
           # Allow non-root user to access PersistentVolume
           securityContext:
 {{ toYaml .Values.drupal.securityContext | indent 12 }}

--- a/drupal/templates/deploy/drupal.yaml
+++ b/drupal/templates/deploy/drupal.yaml
@@ -70,29 +70,6 @@ spec:
           initialDelaySeconds: 1
           periodSeconds: 5
 {{- end  }}
-{{- if .Values.postgresql.pgbouncer.enabled }}
-      - name: pgbouncer
-        image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 5432
-        volumeMounts:
-          - name: configfiles
-            mountPath: "/etc/pgbouncer"
-            readOnly: true
-        livenessProbe:
-          tcpSocket:
-            port: 5432
-          periodSeconds: 60
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ['all']
-{{- end  }}
         env:
 {{- if .Values.external.enabled }}
         - name: EXTERNAL_PASSWORD
@@ -203,18 +180,41 @@ spec:
         - name: twig-cache
           mountPath: /cache/twig
         - name: config-sync
-          mountPath: /config/sync
+          mountPath: /private/config/sync
 {{- if not .Values.drupal.disableDefaultFilesMount }}
         - name: files
           mountPath: /var/www/html/sites/default/files
           subPath: public
         - name: files
-          mountPath: /var/www/private
+          mountPath: /private
           subPath: private
 {{- end }}
 {{- if .Values.drupal.volumeMounts }}
 {{ toYaml .Values.drupal.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.postgresql.pgbouncer.enabled }}
+      - name: pgbouncer
+        image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 5432
+        volumeMounts:
+          - name: configfiles
+            mountPath: "/etc/pgbouncer"
+            readOnly: true
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          periodSeconds: 60
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ['all']
+{{- end  }}
       {{- if .Values.drupal.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.drupal.imagePullSecrets | indent 8 }}

--- a/drupal/templates/job/post-install-site-install.yaml
+++ b/drupal/templates/job/post-install-site-install.yaml
@@ -89,12 +89,12 @@ spec:
               set +e
               find sites/default/files/ -type f -print0 | xargs -0 rm
               find sites/default/files/ -mindepth 1 -type d -print0 | xargs -0 rmdir
-              find /var/www/private/ -type f -print0 | xargs -0 rm
-              find /var/www/private/ -mindepth 1 -type d -print0 | xargs -0 rmdir
+              find /private/ -type f -print0 | xargs -0 rm
+              find /private/ -mindepth 1 -type d -print0 | xargs -0 rmdir
               set -e
 
               tar -zxf /backup/$BACKUPNAME/files.tar.gz --directory sites/default/files --no-acls --no-xattrs -m --no-same-permissions --no-overwrite-dir
-              tar -zxf /backup/$BACKUPNAME/private.tar.gz --directory /var/www/private --no-acls --no-xattrs -m --no-same-permissions --no-overwrite-dir
+              tar -zxf /backup/$BACKUPNAME/private.tar.gz --directory /private --no-acls --no-xattrs -m --no-same-permissions --no-overwrite-dir
 
               # Run database updates
               {{- if .Values.drupal.cacheRebuildBeforeDatabaseMigration }}
@@ -227,29 +227,6 @@ spec:
               {{- if .Values.drupal.extraInstallScripts }}
               {{ .Values.drupal.extraInstallScripts | nindent 14}}
               {{- end }}
-{{- if .Values.postgresql.pgbouncer.enabled }}
-      - name: pgbouncer
-        image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 5432
-        volumeMounts:
-          - name: configfiles
-            mountPath: "/etc/pgbouncer"
-            readOnly: true
-        livenessProbe:
-          tcpSocket:
-            port: 5432
-          periodSeconds: 60
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ['all']
-{{- end  }}
         env:
 {{- if .Values.external.enabled }}
         - name: EXTERNAL_PASSWORD
@@ -356,7 +333,7 @@ spec:
         - name: twig-cache
           mountPath: /cache/twig
         - name: config-sync
-          mountPath: /config/sync
+          mountPath: /private/config/sync
 {{- if .Values.drupal.restore.enabled }}
         - name: backup
           mountPath: /backup
@@ -366,12 +343,35 @@ spec:
           mountPath: /var/www/html/sites/default/files
           subPath: public
         - name: files
-          mountPath: /var/www/private
+          mountPath: /private
           subPath: private
 {{- end }}
 {{- if .Values.drupal.volumeMounts }}
 {{ toYaml .Values.drupal.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.postgresql.pgbouncer.enabled }}
+      - name: pgbouncer
+        image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 5432
+        volumeMounts:
+          - name: configfiles
+            mountPath: "/etc/pgbouncer"
+            readOnly: true
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          periodSeconds: 60
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ['all']
+{{- end  }}
       {{- if .Values.drupal.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.drupal.imagePullSecrets | indent 8 }}
@@ -395,7 +395,7 @@ spec:
       - name: files
         persistentVolumeClaim:
           claimName: {{ template "drupal.fullname" . }}-drupal
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- else if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
       - name: files-public
         persistentVolumeClaim:
           claimName: {{ include "drupal.fullname" . }}-public
@@ -413,5 +413,4 @@ spec:
 {{- end }}
 {{- if .Values.drupal.volumes }}
 {{ toYaml .Values.drupal.volumes | indent 6 }}
-{{- end }}
 {{- end }}

--- a/drupal/templates/job/post-upgrade-reconfigure.yaml
+++ b/drupal/templates/job/post-upgrade-reconfigure.yaml
@@ -166,29 +166,6 @@ spec:
               {{- if .Values.drupal.extraUpgradeScripts }}
               {{ .Values.drupal.extraUpgradeScripts | nindent 14}}
               {{- end }}
-{{- if .Values.postgresql.pgbouncer.enabled }}
-      - name: pgbouncer
-        image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 5432
-        volumeMounts:
-          - name: configfiles
-            mountPath: "/etc/pgbouncer"
-            readOnly: true
-        livenessProbe:
-          tcpSocket:
-            port: 5432
-          periodSeconds: 60
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ['all']
-{{- end  }}
         env:
 {{- if .Values.external.enabled }}
         - name: EXTERNAL_PASSWORD
@@ -296,18 +273,41 @@ spec:
         - name: twig-cache
           mountPath: /cache/twig
         - name: config-sync
-          mountPath: /config/sync
+          mountPath: /private/config/sync
 {{- if not .Values.drupal.disableDefaultFilesMount }}
         - name: files
           mountPath: /var/www/html/sites/default/files
           subPath: public
         - name: files
-          mountPath: /var/www/private
+          mountPath: /private
           subPath: private
 {{- end }}
 {{- if .Values.drupal.volumeMounts }}
 {{ toYaml .Values.drupal.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.postgresql.pgbouncer.enabled }}
+      - name: pgbouncer
+        image: mcr.microsoft.com/azure-oss-db-tools/pgbouncer-sidecar:latest
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 5432
+        volumeMounts:
+          - name: configfiles
+            mountPath: "/etc/pgbouncer"
+            readOnly: true
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          periodSeconds: 60
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ['all']
+{{- end  }}
       {{- if .Values.drupal.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.drupal.imagePullSecrets | indent 8 }}
@@ -327,7 +327,7 @@ spec:
       - name: files
         persistentVolumeClaim:
           claimName: {{ template "drupal.fullname" . }}-drupal
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- else if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
       - name: files-public
         persistentVolumeClaim:
           claimName: {{ include "drupal.fullname" . }}-public
@@ -345,5 +345,4 @@ spec:
 {{- end }}
 {{- if .Values.drupal.volumes }}
 {{ toYaml .Values.drupal.volumes | indent 6 }}
-{{- end }}
 {{- end }}

--- a/drupal/values-hostpath-kind.yaml
+++ b/drupal/values-hostpath-kind.yaml
@@ -73,7 +73,7 @@ drupal:
   healthcheck:
     enabled: true
 
-  # Allows custom /var/www/html/sites/default/files and /var/www/private mounts
+  # Allows custom /var/www/html/sites/default/files and /private mounts
   disableDefaultFilesMount: true
 
   volumes:
@@ -88,7 +88,7 @@ drupal:
     - name: files-public
       mountPath: /var/www/html/sites/default/files
     - name: files-private
-      mountPath: /var/www/private
+      mountPath: /private
 
 nginx:
   image: drupalwxt/site-wxt

--- a/drupal/values-hostpath-microk8s.yaml
+++ b/drupal/values-hostpath-microk8s.yaml
@@ -68,7 +68,7 @@ drupal:
   healthcheck:
     enabled: true
 
-  # Allows custom /var/www/html/sites/default/files and /var/www/private mounts
+  # Allows custom /var/www/html/sites/default/files and /private mounts
   disableDefaultFilesMount: true
 
 
@@ -84,7 +84,7 @@ drupal:
     - name: files-public
       mountPath: /var/www/html/sites/default/files
     - name: files-private
-      mountPath: /var/www/private
+      mountPath: /private
 
 nginx:
   # Set your cluster's DNS resolution service here

--- a/drupal/values-nfs-azurefile.yaml
+++ b/drupal/values-nfs-azurefile.yaml
@@ -51,7 +51,7 @@ drupal:
   healthcheck:
     enabled: true
 
-  # Allows custom /var/www/html/sites/default/files and /var/www/private mounts
+  # Allows custom /var/www/html/sites/default/files and /private mounts
   disableDefaultFilesMount: true
 
   # volumes: {}
@@ -60,7 +60,7 @@ drupal:
     - name: files-public
       mountPath: /var/www/html/sites/default/files
     - name: files-private
-      mountPath: /var/www/private
+      mountPath: /private
 
 nginx:
   # Set your cluster's DNS resolution service here

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -150,7 +150,7 @@ drupal:
     accessMode: ReadWriteOnce
     size: 8Gi
 
-  # Allows custom /var/www/html/sites/default/files and /var/www/private mounts
+  # Allows custom /var/www/html/sites/default/files and /private mounts
   disableDefaultFilesMount: false
   volumes:
   #  - name: nothing

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -4,7 +4,6 @@ chart-dirs:
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - helm=https://charts.helm.sh/stable
-  - stable=https://kubernetes-charts.storage.googleapis.com
   - statcan=https://statcan.github.io/charts
   - minio=https://helm.min.io/
 check-version-increment: true


### PR DESCRIPTION
Move both the private drupal files and configuration sync into the "/private" mount which will link to Azure Files.

The only question I have is knowing the PVC will mount to /private can I for the config-sync directory with emptydir set to /private/config/sync ?

This was done as a request so that can follow Drupal best practice of placement of configuration files.

https://www.drupal.org/docs/configuration-management/changing-the-storage-location-of-the-sync-directory