### PR TITLE
Upgraded Ingress apiVersion to networking.k8s.io/v1

### DIFF
--- a/drupal/templates/ing/drupal.yaml
+++ b/drupal/templates/ing/drupal.yaml
@@ -3,7 +3,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $varnishEnabled := .Values.varnish.enabled -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,13 +32,19 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - backend:
+          - pathType: Prefix
+            path: {{ $ingressPath }}
+            backend:
           {{- if $varnishEnabled }}
-              serviceName: {{ $releaseName }}-varnish
-              servicePort: 80
+              service:
+                name: {{ $releaseName }}-varnish
+                port:
+                  number: 80
           {{- else }}
-              serviceName: {{ $fullName }}-nginx
-              servicePort: 80
+              service:
+                name: {{ $fullName }}-nginx
+                port:
+                  number: 80
           {{- end }}
   {{- end }}
 {{- end }}

--- a/drupal/templates/ing/drupal.yaml
+++ b/drupal/templates/ing/drupal.yaml
@@ -3,7 +3,11 @@
 {{- $releaseName := .Release.Name -}}
 {{- $varnishEnabled := .Values.varnish.enabled -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,6 +36,7 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
+        {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
           - pathType: Prefix
             path: {{ $ingressPath }}
             backend:
@@ -46,5 +51,15 @@ spec:
                 port:
                   number: 80
           {{- end }}
+        {{- else }}
+          - backend:
+          {{- if $varnishEnabled }}
+              serviceName: {{ $releaseName }}-varnish
+              servicePort: 80
+          {{- else }}
+              serviceName: {{ $fullName }}-nginx
+              servicePort: 80
+          {{- end }}
+        {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Kubernetes Ingress is now out of beta with the updated `networking.k8s.io/v1` apiVersion requiring some changes to the Ingress YAML. Tested this updated Ingress with our `v1.19.3` AKS cluster and works well.