### PR TITLE
Fixed invalid if/end block

### DIFF
--- a/drupal/templates/job/post-install-site-install.yaml
+++ b/drupal/templates/job/post-install-site-install.yaml
@@ -51,7 +51,6 @@ spec:
 {{ toYaml .Values.drupal.initContainers | indent 8 }}
 {{- end }}
 {{- end }}
-{{- end }}
       containers:
       - name: drush
         image: "{{ .Values.drupal.image }}:{{ default .Chart.AppVersion .Values.drupal.tag }}"
@@ -383,4 +382,5 @@ spec:
 {{- end }}
 {{- if .Values.drupal.volumes }}
 {{ toYaml .Values.drupal.volumes | indent 6 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Hey again! Was attempting to deploy a new instance of Drupal with the latest Helm chart but kept running into this error, even though I had the `drupal.install` value set to `false`:

`Error: YAML parse error on drupal/templates/job/post-install-site-install.yaml: error converting YAML to JSON: yaml: line 72: did not find expected '-' indicator`

Had to do a lot of debugging through this file but turns out the `{{- end }}` statement for `{{- if .Values.drupal.install }}` was just in the wrong spot. Helm deployment worked after I moved it to the end of the file.