### PR TITLE
Feat(helm): add resources/podAnnotations to Drupal

### DIFF
--- a/drupal/templates/deploy/drupal.yaml
+++ b/drupal/templates/deploy/drupal.yaml
@@ -22,6 +22,10 @@ spec:
         app.kubernetes.io/name: {{ include "drupal.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         tier: drupal
+{{- if .Values.drupal.podAnnotations }}
+      annotations:
+{{ toYaml .Values.drupal.podAnnotations | indent 8 }}
+{{- end }}        
     spec:
 {{- if or (.Values.drupal.initContainers) (or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled)) }}
       initContainers:
@@ -125,6 +129,10 @@ spec:
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}
 {{- end }}
+{{- if .Values.drupal.resources }}
+        resources:
+{{ toYaml .Values.drupal.resources | indent 10 }}        
+{{- end  }} 
         ports:
         - containerPort: 9000
           name: tcp-php-fpm

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -183,6 +183,15 @@ drupal:
   configSplit:
     enabled: false
 
+  podAnnotations: {}
+  resources: {}
+    # requests:
+    #   memory: "256Mi"
+    #   cpu: "100m"
+    # limits:
+    #   memory: "1Gi"
+    #   cpu: "500m"
+
 nginx:
   ## Nginx image version
   ## ref: https://hub.docker.com/drupalwxt/site-wxt/tags/


### PR DESCRIPTION
Adds an optional block for `resources` and `podAnnotations` to the Drupal deployment.  

Fixes #58 