### PR TITLE
fix: set nginx imagePullPolicy from values

### DIFF
--- a/drupal/templates/deploy/nginx.yaml
+++ b/drupal/templates/deploy/nginx.yaml
@@ -46,6 +46,7 @@ spec:
 {{- end }}
       containers:
       - image: "{{ .Values.nginx.image }}:{{ default (print .Chart.AppVersion "-nginx") .Values.nginx.tag }}"
+        imagePullPolicy: {{ default "" .Values.nginx.imagePullPolicy | quote }}
         name: nginx
         ports:
         - name: http

--- a/drupal7/templates/deploy/nginx.yaml
+++ b/drupal7/templates/deploy/nginx.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       containers:
       - image: "{{ .Values.nginx.image }}:{{ default (print .Chart.AppVersion "-nginx") .Values.nginx.tag }}"
+        imagePullPolicy: {{ default "" .Values.nginx.imagePullPolicy | quote }}
         name: nginx
         ports:
         - name: http


### PR DESCRIPTION
Simple fix to use the chart's `nginx.imagePullPolicy` value, based on some less simple debugging in our dev cluster where we're using a `latest` tag 😅