### PR TITLE
fix(drupal7): Correct default value type of the additionalCrons object

### DIFF
--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -121,7 +121,7 @@ drupal:
     # Defaults to once an hour
     schedule: '0 * * * *'
 
-  additionalCrons: []
+  additionalCrons: {}
     # example:
     #   # Run at midnight UTC
     #   schedule: '0 0 * * *'


### PR DESCRIPTION
I believe this is the cause of some warnings in `helm` when configuring additional crons.