### PR TITLE
fix default value type for additionalCrons

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.11.17
+version: 0.11.18
 appVersion: 4.1.0
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -127,7 +127,7 @@ drupal:
     # Defaults to once an hour
     schedule: '0 * * * *'
 
-  additionalCrons: []
+  additionalCrons: {}
     # example:
     #   # Run at midnight UTC
     #   schedule: '0 0 * * *'


### PR DESCRIPTION
This replicates a fix made by @zachomedia in drupal7 - #86 - for drupal 8/9 