### PR TITLE
feat(nginx): allow custom nginx locations to be configured in the values

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: 4.1.1
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/conf/nginx.conf
+++ b/drupal/conf/nginx.conf
@@ -80,6 +80,8 @@ http {
 {{- end }}
       }
 
+      {{ .Values.nginx.customLocations }}
+
       location ~ \.php$ {
         proxy_intercept_errors on;
         include fastcgi_params;

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -290,6 +290,8 @@ nginx:
 
   serviceType: ClusterIP
 
+  customLocations: ""
+
   persistence:
     enabled: false
     ## A manually managed Persistent Volume and Claim

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.1.20
+version: 0.1.21
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/conf/nginx.conf
+++ b/drupal7/conf/nginx.conf
@@ -72,6 +72,8 @@ http {
           try_files $uri $uri/ /index.html /index.php?$query_string;
       }
 
+      {{ .Values.nginx.customLocations }}
+
       location ~ \.php$ {
         proxy_intercept_errors on;
         include fastcgi_params;

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -254,6 +254,8 @@ nginx:
 
   serviceType: ClusterIP
 
+  customLocations: ""
+
   persistence:
     enabled: false
     ## A manually managed Persistent Volume and Claim


### PR DESCRIPTION
I have a use case for needing a second location entry point from nginx into Drupal. I believe this could be accomplished transparently by making the nginx configuration configurable in a similar way to the Varnish config.

I think the following change is a reasonable and transparent way of adding that support, but I'd appreciate if someone could review the sanity of this approach :)