### PR TITLE
Update Drupal confs to support DB init_commands

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: 4.1.2
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/conf/settings.d8.php
+++ b/drupal/conf/settings.d8.php
@@ -103,6 +103,16 @@ $databases['default']['default'] = array (
   'prefix' => '',
   'namespace' => 'Drupal\Core\Database\Driver\{{ .Values.external.driver }}',
   'driver' => '{{ .Values.external.driver }}',
+  {{- if .Values.external.initCommands }}
+  'init_commands' => array (
+  {{- range .Values.external.initCommands }}
+    {{- range $key, $value := . }}
+    '{{ $key }}' => {{ $value | quote }},
+    {{- end }}
+  {{- end }}
+  ),
+  {{- end }}
+  {{- if .Values.external.pdo }}
   'pdo' => array (
   {{- range .Values.external.pdo }}
     {{- range $key, $value := . }}
@@ -110,6 +120,7 @@ $databases['default']['default'] = array (
     {{- end }}
   {{- end }}
   ),
+  {{- end }}
 );
 {{- else if .Values.mysql.enabled }}
 $databases['default']['default'] = array (

--- a/drupal/conf/settings.d9.php
+++ b/drupal/conf/settings.d9.php
@@ -105,6 +105,16 @@ $databases['default']['default'] = [
   'namespace' => 'Drupal\Core\Database\Driver\{{ .Values.external.driver }}',
   'driver' => '{{ .Values.external.driver }}',
   'collation' => 'utf8mb4_general_ci',
+  {{- if .Values.external.initCommands }}
+  'init_commands' => [
+  {{- range .Values.external.initCommands }}
+    {{- range $key, $value := . }}
+    '{{ $key }}' => {{ $value | quote }},
+    {{- end }}
+  {{- end }}
+  ],
+  {{- end }}
+  {{- if .Values.external.pdo }}
   'pdo' => [
   {{- range .Values.external.pdo }}
     {{- range $key, $value := . }}
@@ -112,6 +122,7 @@ $databases['default']['default'] = [
     {{- end }}
   {{- end }}
   ],
+  {{- end }}
 ];
 {{- else if .Values.mysql.enabled }}
 $databases['default']['default'] = [

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -367,6 +367,10 @@ external:
   database: wxt
   user: wxt
   password: password
+  # initCommands:
+  #   - isolation: "SET SESSION tx_isolation='READ-COMMITTED'"
+  # pdo:
+  #   - PDO::MYSQL_ATTR_SSL_CA: '/etc/ssl/certs/ca-certificates.crt'
 
 # Shared Disk logic
 sharedDisk:

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -313,6 +313,10 @@ external:
   database: wetkit
   user: wetkit
   password: password
+  # initCommands:
+  #   - isolation: "SET SESSION tx_isolation='READ-COMMITTED'"
+  # pdo:
+  #   - PDO::MYSQL_ATTR_SSL_CA: '/etc/ssl/certs/ca-certificates.crt'
 
 # Shared Disk logic
 sharedDisk:


### PR DESCRIPTION
I'm hoping to add a new value to the external DB config to enable more customization using the Drupal `init_commands` DB settings field. This will allow a developer to modify DB variables on startup such as `sql_mode` or the `isolation` level using the format in the example below:

```
external:
  initCommands:
    - isolation: "SET SESSION tx_isolation='READ-COMMITTED'"
```

These Helm values will then be applied to the `$databases` Drupal array as follows:

```
$databases['default']['default'] = [
  'init_commands' => [
    'isolation' => "SET SESSION tx_isolation='READ-COMMITTED'",
  ],
];
```