### PR TITLE
Update ingress configs with ingressClassName

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.13.1
+version: 0.13.3
 appVersion: 4.1.2
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/templates/ing/drupal.yaml
+++ b/drupal/templates/ing/drupal.yaml
@@ -21,6 +21,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -4,8 +4,8 @@
 ##
 ingress:
   enabled: false
+  # className: nginx
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
   hosts:

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.1.21
+version: 0.1.23
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/templates/ing/drupal.yaml
+++ b/drupal7/templates/ing/drupal.yaml
@@ -21,6 +21,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -4,8 +4,8 @@
 ##
 ingress:
   enabled: false
+  # className: nginx
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
   hosts:

--- a/solr/Chart.yaml
+++ b/solr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/solr/templates/ing/solr.yaml
+++ b/solr/templates/ing/solr.yaml
@@ -17,6 +17,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/solr/values.yaml
+++ b/solr/values.yaml
@@ -4,8 +4,8 @@
 ##
 ingress:
   enabled: false
+  # className: nginx
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
   hosts:


### PR DESCRIPTION
The latest Kubernetes versions are removing the deprecated `kubernetes.io/ingress.class` annotation for selecting an Nginx ingress controller and are pushing to use the `.spec.ingressClassName` field (see: https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#what-to-do). Adding this into the Ingress configs will allow a developer to set their Ingress class using the format below:

```
ingress:
  enabled: true
  className: my-nginx-class
```