### PR TITLE
Optional init for media icons folder

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.13.1
+version: 0.13.4
 appVersion: 4.1.2
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/templates/deploy/drupal.yaml
+++ b/drupal/templates/deploy/drupal.yaml
@@ -66,7 +66,7 @@ spec:
             - name: files-public
               mountPath: /mnt/azure
 {{- end }}
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- if or (and .Values.azureFile.enabled .Values.azureFile.initMediaIconsFolder) (and .Values.sharedDisk.enabled .Values.sharedDisk.initMediaIconsFolder) }}
         - name: init-media-icons-folder
           image: 'alpine:3.10'
           command:

--- a/drupal/templates/job/post-install-site-install.yaml
+++ b/drupal/templates/job/post-install-site-install.yaml
@@ -44,7 +44,7 @@ spec:
             - name: files-public
               mountPath: /mnt/azure
 {{- end }}
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- if or (and .Values.azureFile.enabled .Values.azureFile.initMediaIconsFolder) (and .Values.sharedDisk.enabled .Values.sharedDisk.initMediaIconsFolder) }}
         - name: init-media-icons-folder
           image: 'alpine:3.10'
           command:

--- a/drupal/templates/job/post-upgrade-reconfigure.yaml
+++ b/drupal/templates/job/post-upgrade-reconfigure.yaml
@@ -44,7 +44,7 @@ spec:
             - name: files-public
               mountPath: /mnt/azure
 {{- end }}
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- if or (and .Values.azureFile.enabled .Values.azureFile.initMediaIconsFolder) (and .Values.sharedDisk.enabled .Values.sharedDisk.initMediaIconsFolder) }}
         - name: init-media-icons-folder
           image: 'alpine:3.10'
           command:

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -371,6 +371,7 @@ external:
 # Shared Disk logic
 sharedDisk:
   enabled: false
+  initMediaIconsFolder: true
 
   annotations: {}
   accessMode: ReadWriteMany
@@ -388,6 +389,7 @@ sharedDisk:
 # Azure File logic
 azureFile:
   enabled: false
+  initMediaIconsFolder: true
 
   annotations: {}
   accessMode: ReadWriteMany

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.1.21
+version: 0.1.24
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/templates/deploy/drupal.yaml
+++ b/drupal7/templates/deploy/drupal.yaml
@@ -49,7 +49,7 @@ spec:
             - name: files-public
               mountPath: /mnt/azure
 {{- end }}
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- if or (and .Values.azureFile.enabled .Values.azureFile.initMediaIconsFolder) (and .Values.sharedDisk.enabled .Values.sharedDisk.initMediaIconsFolder) }}
         - name: init-media-icons-folder
           image: 'alpine:3.10'
           command:

--- a/drupal7/templates/job/post-install-site-install.yaml
+++ b/drupal7/templates/job/post-install-site-install.yaml
@@ -44,7 +44,7 @@ spec:
             - name: files-public
               mountPath: /mnt/azure
 {{- end }}
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- if or (and .Values.azureFile.enabled .Values.azureFile.initMediaIconsFolder) (and .Values.sharedDisk.enabled .Values.sharedDisk.initMediaIconsFolder) }}
         - name: init-media-icons-folder
           image: 'alpine:3.10'
           command:

--- a/drupal7/templates/job/post-upgrade-reconfigure.yaml
+++ b/drupal7/templates/job/post-upgrade-reconfigure.yaml
@@ -44,7 +44,7 @@ spec:
             - name: files-public
               mountPath: /mnt/azure
 {{- end }}
-{{- if or (.Values.azureFile.enabled) (.Values.sharedDisk.enabled) }}
+{{- if or (and .Values.azureFile.enabled .Values.azureFile.initMediaIconsFolder) (and .Values.sharedDisk.enabled .Values.sharedDisk.initMediaIconsFolder) }}
         - name: init-media-icons-folder
           image: 'alpine:3.10'
           command:

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -317,6 +317,7 @@ external:
 # Shared Disk logic
 sharedDisk:
   enabled: false
+  initMediaIconsFolder: true
 
   annotations: {}
   accessMode: ReadWriteMany
@@ -334,6 +335,7 @@ sharedDisk:
 # Azure File logic
 azureFile:
   enabled: false
+  initMediaIconsFolder: true
 
   annotations: {}
   accessMode: ReadWriteMany


### PR DESCRIPTION
Last pull request, I swear! Not a major one but this modification will allow a developer to disable the `init-media-icons-folder` initContainer if it's no longer required (such as when using a persistent volume and the folder already exists). The boolean defaults to `true` but gives one the ability to turn it off as necessary.