### PR TITLE
Update CronJob apiVersion

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.13.4
+version: 0.13.5
 appVersion: 4.1.2
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/templates/cronjob/cron.yaml
+++ b/drupal/templates/cronjob/cron.yaml
@@ -7,7 +7,11 @@
 {{- $values := .Values }}
 {{- range $cronName, $cron := .Values.drupal.additionalCrons }}
 ---
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ $fullName }}-{{ $cronName }}

--- a/drupal/templates/cronjob/drupal-backup.yaml
+++ b/drupal/templates/cronjob/drupal-backup.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.drupal.backup.enabled }}
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ template "drupal.fullname" . }}-drupal-backup

--- a/drupal/templates/cronjob/drupal.yaml
+++ b/drupal/templates/cronjob/drupal.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.drupal.cron.enabled }}
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ template "drupal.fullname" . }}-drupal-cron

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.1.24
+version: 0.1.25
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/templates/cronjob/cron.yaml
+++ b/drupal7/templates/cronjob/cron.yaml
@@ -7,7 +7,11 @@
 {{- $values := .Values }}
 {{- range $cronName, $cron := .Values.drupal.additionalCrons }}
 ---
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ $fullName }}-{{ $cronName }}

--- a/drupal7/templates/cronjob/drupal-backup.yaml
+++ b/drupal7/templates/cronjob/drupal-backup.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.drupal.backup.enabled }}
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ template "drupal7.fullname" . }}-drupal-backup

--- a/drupal7/templates/cronjob/drupal.yaml
+++ b/drupal7/templates/cronjob/drupal.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.drupal.cron.enabled }}
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ template "drupal7.fullname" . }}-drupal-cron


### PR DESCRIPTION
CronJobs built into this chart are still using the `batch/v1beta1` apiVersion when they have been out of beta since Kubernetes v1.21 (see https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/#cronjobs-graduate-to-stable).

Added a `semVer` check for clusters meeting the `1.21` requirements to use `batch/v1` with the fallback still in place.