### PR TITLE
Add PodDisruptionBudget to charts

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.13.4
+version: 0.13.6
 appVersion: 4.1.2
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/templates/pdb/poddisruptionbudget.yaml
+++ b/drupal/templates/pdb/poddisruptionbudget.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.drupal.podDisruptionBudget }}
+{{- $name := include "drupal.name" . -}}
+{{- $fullName := include "drupal.fullname" . -}}
+{{- $chartName := include "drupal.chart" . -}}
+{{- $release := .Release }}
+{{- $values := .Values }}
+---
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ $name }}
+    helm.sh/chart: {{ $chartName }}
+    app.kubernetes.io/instance: {{ $release.Name }}
+    app.kubernetes.io/managed-by: {{ $release.Service }}
+spec:
+  {{- if $values.drupal.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ $values.drupal.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if $values.drupal.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ $values.drupal.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $name }}
+      app.kubernetes.io/instance: {{ $release.Name }}
+{{- end }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -136,6 +136,10 @@ drupal:
   cacheRebuildBeforeDatabaseMigration: true
   lightningUpdate: true
 
+  # podDisruptionBudget:
+  #   minAvailable: 1
+  #   maxUnavailable: 1
+
   # Configure the Drupal cron
   cron:
     # When enabled, a CronJob will run the job based on the schedule

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.1.24
+version: 0.1.26
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/templates/pdb/poddisruptionbudget.yaml
+++ b/drupal7/templates/pdb/poddisruptionbudget.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.drupal.podDisruptionBudget }}
+{{- $name := include "drupal7.name" . -}}
+{{- $fullName := include "drupal7.fullname" . -}}
+{{- $chartName := include "drupal7.chart" . -}}
+{{- $release := .Release }}
+{{- $values := .Values }}
+---
+{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ $name }}
+    helm.sh/chart: {{ $chartName }}
+    app.kubernetes.io/instance: {{ $release.Name }}
+    app.kubernetes.io/managed-by: {{ $release.Service }}
+spec:
+  {{- if $values.drupal.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ $values.drupal.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if $values.drupal.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ $values.drupal.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $name }}
+      app.kubernetes.io/instance: {{ $release.Name }}
+{{- end }}

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -112,6 +112,10 @@ drupal:
   reconfigure: true
   cacheRebuildBeforeDatabaseMigration: true
 
+  # podDisruptionBudget:
+  #   minAvailable: 1
+  #   maxUnavailable: 1
+
   # Configure the Drupal cron
   cron:
     # When enabled, a CronJob will run the job based on the schedule


### PR DESCRIPTION
One last handy feature I was hoping to add to the `helm-drupal` chart was the use of `PodDisruptionBudget`s if a developer wanted to ensure a certain amount of pods remain available during any k8s upgrades or node updates.

Added in the Helm values as commented-out fields.