### PR TITLE
Make drush updb optional before DB Migration

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.17.0
+version: 0.17.1
 appVersion: 4.2.1
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/templates/job/post-upgrade-reconfigure.yaml
+++ b/drupal/templates/job/post-upgrade-reconfigure.yaml
@@ -90,7 +90,9 @@ spec:
               {{- if .Values.drupal.cacheRebuildBeforeDatabaseMigration }}
               drush -y cache:rebuild
               {{- end }}
+              {{- if .Values.drupal.updateDBBeforeDatabaseMigration }}
               drush -y updatedb
+              {{- end }}
 
               # Lightning updates
               {{- if .Values.drupal.lightningUpdate }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -140,6 +140,7 @@ drupal:
   # Reconfigure on upgrade
   reconfigure: true
   cacheRebuildBeforeDatabaseMigration: true
+  updateDBBeforeDatabaseMigration: true
   lightningUpdate: false
   wxtUpdate: false
 

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/templates/job/post-upgrade-reconfigure.yaml
+++ b/drupal7/templates/job/post-upgrade-reconfigure.yaml
@@ -90,7 +90,9 @@ spec:
               {{- if .Values.drupal.cacheRebuildBeforeDatabaseMigration }}
               drush -y cc all
               {{- end }}
+              {{- if .Values.drupal.updateDBBeforeDatabaseMigration }}
               drush -y updatedb
+              {{- end }}
 
               # Change WxT theme
               {{- if .Values.drupal.wxtTheme }}

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -117,6 +117,7 @@ drupal:
   # Reconfigure on upgrade
   reconfigure: true
   cacheRebuildBeforeDatabaseMigration: true
+  updateDBBeforeDatabaseMigration: true
 
   # Restrict how many attempt install and/or reconfigure jobs will try in case of failure. Default is 6.
   # backoffLimitInstall: 1


### PR DESCRIPTION
In some cases, running drush updb before a DB migration is causing issues. Making this optional and handling the updb as part of the extra upgrade script is a better option.