### PR TITLE
Add option to disable gzip compression

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal
 apiVersion: v2
 type: application
-version: 0.17.0
+version: 0.17.2
 appVersion: 4.2.1
 description: Drupal 8/9 variant of the Web Experience Toolkit (WxT).
 keywords:

--- a/drupal/conf/nginx.conf
+++ b/drupal/conf/nginx.conf
@@ -18,7 +18,11 @@ http {
   client_max_body_size 20m;
 {{- end }}
   default_type application/octet-stream;
+{{- if .Values.nginx.gzip }}
   gzip on;
+{{- else }}
+  gzip off;
+{{- end }}
   gzip_buffers 16 8k;
   gzip_comp_level 4;
   gzip_disable msie6;

--- a/drupal/conf/nginx.conf
+++ b/drupal/conf/nginx.conf
@@ -20,15 +20,13 @@ http {
   default_type application/octet-stream;
 {{- if .Values.nginx.gzip }}
   gzip on;
-{{- else }}
-  gzip off;
-{{- end }}
   gzip_buffers 16 8k;
   gzip_comp_level 4;
   gzip_disable msie6;
   gzip_proxied off;
   gzip_types application/json;
   gzip_vary on;
+{{- end }}
   include /etc/nginx/mime.types;
   index index.html index.htm;
   keepalive_timeout 240;

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -364,6 +364,7 @@ nginx:
     enabled: true
     fsGroup: 33
 
+  gzip: true
   client_max_body_size: 20m
   real_ip_header: X-Forwarded-For
 

--- a/drupal7/Chart.yaml
+++ b/drupal7/Chart.yaml
@@ -1,7 +1,7 @@
 name: drupal7
 apiVersion: v2
 type: application
-version: 0.2.2
+version: 0.2.4
 appVersion: "4.54"
 description: Drupal 7 variant of the Web Experience Toolkit (WetKit).
 keywords:

--- a/drupal7/conf/nginx.conf
+++ b/drupal7/conf/nginx.conf
@@ -18,7 +18,11 @@ http {
   client_max_body_size 20m;
 {{- end }}
   default_type application/octet-stream;
+{{- if .Values.nginx.gzip }}
   gzip on;
+{{- else }}
+  gzip off;
+{{- end }}
   gzip_buffers 16 8k;
   gzip_comp_level 4;
   gzip_disable msie6;

--- a/drupal7/conf/nginx.conf
+++ b/drupal7/conf/nginx.conf
@@ -20,15 +20,13 @@ http {
   default_type application/octet-stream;
 {{- if .Values.nginx.gzip }}
   gzip on;
-{{- else }}
-  gzip off;
-{{- end }}
   gzip_buffers 16 8k;
   gzip_comp_level 4;
   gzip_disable msie6;
   gzip_proxied off;
   gzip_types application/json;
   gzip_vary on;
+{{- end }}
   include /etc/nginx/mime.types;
   index index.html index.htm;
   keepalive_timeout 240;

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -309,6 +309,7 @@ nginx:
     enabled: true
     fsGroup: 33
 
+  gzip: true
   client_max_body_size: 20m
   real_ip_header: X-Forwarded-For
 


### PR DESCRIPTION
Ran into a use case where gzip compression needed to be disabled which currently can't be configured. This change should allow developers to disable it if necessary while having it be on by default.