### PR TITLE
Allow ability to suppress tar errors on file restore

### DIFF
--- a/drupal/templates/job/post-install-site-install.yaml
+++ b/drupal/templates/job/post-install-site-install.yaml
@@ -126,8 +126,14 @@ spec:
               set -e
 
               echo "Restoring files"
+              {{- if .Values.drupal.restore.suppressTarErrors }}
+              set +e
+              {{- end }}
               tar -zxf /backup/$BACKUPNAME/files.tar.gz --directory sites/default/files --no-acls --no-xattrs -m --no-same-permissions --no-overwrite-dir
               tar -zxf /backup/$BACKUPNAME/private.tar.gz --directory /private --no-acls --no-xattrs -m --no-same-permissions --no-overwrite-dir
+              {{- if .Values.drupal.restore.suppressTarErrors }}
+              set -e
+              {{- end }}
               echo "Files restored"
               {{- end }}
 

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -126,6 +126,7 @@ drupal:
     name: latest
     db: true
     files: false
+    suppressTarErrors: false
 
     # Convert MyISAM to InnoDB
     convert: false

--- a/drupal7/templates/job/post-install-site-install.yaml
+++ b/drupal7/templates/job/post-install-site-install.yaml
@@ -126,8 +126,14 @@ spec:
               set -e
 
               echo "Restoring files"
+              {{- if .Values.drupal.restore.suppressTarErrors }}
+              set +e
+              {{- end }}
               tar -zxf /backup/$BACKUPNAME/files.tar.gz --directory sites/default/files --no-acls --no-xattrs -m --no-same-permissions --no-overwrite-dir
               tar -zxf /backup/$BACKUPNAME/private.tar.gz --directory /private --no-acls --no-xattrs -m --no-same-permissions --no-overwrite-dir
+              {{- if .Values.drupal.restore.suppressTarErrors }}
+              set -e
+              {{- end }}
               echo "Files restored"
               {{- end }}
 

--- a/drupal7/values.yaml
+++ b/drupal7/values.yaml
@@ -103,6 +103,7 @@ drupal:
     name: latest
     db: true
     files: false
+    suppressTarErrors: false
 
     # Convert MyISAM to InnoDB
     convert: false


### PR DESCRIPTION
Since tar currently throws errors while restoring files when working with an azure file share, I've added in a way to suppress errors from the tar commands in the file restore step. By default this will change nothing, but we can activate this through Terraform.

This can be reverted once the core issue with TAR is resolved.