### PR TITLE
feat(helm) Update semver comparison to support suffixes

### DIFF
--- a/charts/drupal/templates/cronjob/cron.yaml
+++ b/charts/drupal/templates/cronjob/cron.yaml
@@ -8,7 +8,7 @@
 {{- $ctx := . }}
 {{- range $cronName, $cron := .Values.drupal.additionalCrons }}
 ---
-{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1

--- a/charts/drupal/templates/cronjob/drupal-backup.yaml
+++ b/charts/drupal/templates/cronjob/drupal-backup.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.drupal.backup.enabled }}
-{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1

--- a/charts/drupal/templates/cronjob/drupal.yaml
+++ b/charts/drupal/templates/cronjob/drupal.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.drupal.cron.enabled }}
-{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1

--- a/charts/drupal/templates/pdb/poddisruptionbudget.yaml
+++ b/charts/drupal/templates/pdb/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@
 {{- $release := .Release }}
 {{- $values := .Values }}
 ---
-{{- if semverCompare ">=1.21" $.Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
Recent change in kubernetes version (on azure) has introduced a version suffix. 

`Server Version: v1.30.14 -> Server Version: v1.31.100-akslts`

This breaks the semver logic on 4 files.

<img width="670" height="325" alt="image" src="https://github.com/user-attachments/assets/f8e4fa7e-e3d7-4721-b0e2-4c3f294eece9" />
